### PR TITLE
Implements #1 (Extend to include String Interpolation)

### DIFF
--- a/FSDv2/Source/Source.vb
+++ b/FSDv2/Source/Source.vb
@@ -4,14 +4,16 @@
   Friend ReadOnly Property ID As Guid
   Public ReadOnly Property Text As String
   Public ReadOnly Property Length As Integer
-  Public ReadOnly Property Kind As SourceKind
+    Public ReadOnly Property Kind As SourceKind
+    Public ReadOnly Property KindOfString As StringKind
 #End Region
 
-  Private Sub New(Text As String, Kind As SourceKind)
-    Me.ID = Guid.NewGuid : Me.Text = If(Text, String.Empty) : Me.Length = Me.Text.Length : Me.Kind = Kind
-  End Sub
+    Private Sub New(Text As String, Kind As SourceKind, KindOfString As StringKind)
+        Me.ID = Guid.NewGuid : Me.Text = If(Text, String.Empty) : Me.Length = Me.Text.Length : Me.Kind = Kind
+        Me.KindOfString = KindOfString
+    End Sub
 
-  Public Function First() As Position?
+    Public Function First() As Position?
     Return Position.Create(Me, If(Length <= 0, -1, 0))
   End Function
 
@@ -21,11 +23,11 @@
     End Get
   End Property
 
-  Public Shared Function Create(Text As String, SourceKind As SourceKind) As Source
-    Return New Source(Text, SourceKind)
-  End Function
+    Public Shared Function Create(Text As String, SourceKind As SourceKind, KindOfString As StringKind) As Source
+        Return New Source(Text, SourceKind, KindOfString)
+    End Function
 
-  Public Shared Operator =(S0 As Source, S1 As Source) As Boolean
+    Public Shared Operator =(S0 As Source, S1 As Source) As Boolean
     Return (S0.ID = S1.ID)
   End Operator
 
@@ -33,10 +35,15 @@
     Return (S0.ID <> S1.ID)
   End Operator
 
-  Public Enum SourceKind As Integer
-    VB_Standard
-    CS_Standard
-    CS_Verbatum
-  End Enum
+    Public Enum SourceKind As Integer
+        VB_Standard
+        CS_Standard
+        CS_Verbatum
+    End Enum
+
+    Public Enum StringKind As Integer
+        StringFormat = 0
+        StringInterpolation = 1
+    End Enum
 
 End Structure

--- a/FSDv2_UnitTests/Arghole_UnitTest/ArgAlign_UnitTest/ArgAlign_UnitTest.vb
+++ b/FSDv2_UnitTests/Arghole_UnitTest/ArgAlign_UnitTest/ArgAlign_UnitTest.vb
@@ -13,8 +13,8 @@ Public Class ArgAlign_UnitTest
   <TestMethod, TestCategory("Tokens.Arghole.ArgAlign")>
   Public Sub _00_()
     Dim Text = ""
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Align.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -24,8 +24,8 @@ Public Class ArgAlign_UnitTest
   <TestMethod, TestCategory("Tokens.Arghole.ArgAlign")>
   Public Sub _01_()
     Dim Text = ",1"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Align.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.ArgHole.Align))
@@ -67,8 +67,8 @@ Public Class ArgAlign_UnitTest
   Public Sub _02_()
     '           0123
     Dim Text = ",  1"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Align.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.ArgHole.Align))
@@ -107,8 +107,8 @@ Public Class ArgAlign_UnitTest
   <TestMethod, TestCategory("Tokens.Arghole.ArgAlign")>
   Public Sub _03_()
     Dim Text = ",-1"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Align.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.ArgHole.Align))
@@ -152,8 +152,8 @@ Public Class ArgAlign_UnitTest
   <TestMethod, TestCategory("Tokens.Arghole.ArgAlign")>
   Public Sub _04_()
     Dim Text = ", -1"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Align.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.ArgHole.Align))
@@ -197,8 +197,8 @@ Public Class ArgAlign_UnitTest
   <TestMethod, TestCategory("Tokens.Arghole.ArgAlign")>
   Public Sub _05_()
     Dim Text = ",1 "
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Align.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.ArgHole.Align))
@@ -236,8 +236,8 @@ Public Class ArgAlign_UnitTest
   <TestMethod, TestCategory("Tokens.Arghole.ArgAlign")>
   Public Sub _06_()
     Dim Text = ", -1 "
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Align.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.ArgHole.Align))
@@ -282,8 +282,8 @@ Public Class ArgAlign_UnitTest
   <TestMethod, TestCategory("Tokens.Arghole.ArgAlign")>
   Public Sub _07_()
     Dim Text = ", -1"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Align.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.ArgHole.Align))
@@ -326,8 +326,8 @@ Public Class ArgAlign_UnitTest
   <TestMethod, TestCategory("Tokens.Arghole.ArgAlign")>
   Public Sub _08_()
     Dim Text = ", 1 "
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Align.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.ArgHole.Align))

--- a/FSDv2_UnitTests/Arghole_UnitTest/ArgFormat_UnitTest/ArgFormat_UnitTests.vb
+++ b/FSDv2_UnitTests/Arghole_UnitTest/ArgFormat_UnitTest/ArgFormat_UnitTests.vb
@@ -15,8 +15,8 @@ Public Class ArgFormat_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _00_()
     Dim Text = ""
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Format.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -26,8 +26,8 @@ Public Class ArgFormat_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _01_()
     Dim Text = ":"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Format.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -47,8 +47,8 @@ Public Class ArgFormat_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _02_()
     Dim Text = ":{{"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Format.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -80,8 +80,8 @@ Public Class ArgFormat_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _03_()
     Dim Text = ":{"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standar, Source.StringKind.StringFormatd)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Format.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -120,8 +120,8 @@ Public Class ArgFormat_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _04_()
     Dim Text = ":{}"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Format.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))

--- a/FSDv2_UnitTests/Arghole_UnitTest/ArgHole_UnitTests.vb
+++ b/FSDv2_UnitTests/Arghole_UnitTest/ArgHole_UnitTests.vb
@@ -16,8 +16,8 @@ Public Class ArgHole_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _00_()
     Dim Text = ""
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind., Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -27,8 +27,8 @@ Public Class ArgHole_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _01_()
     Dim Input = "{"
-    Dim TheSource = Source.Create(Input, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Input, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim ParseResult = FormatString.ArgHole.TryParse(FirstPos)
     Assert.IsNotNull(ParseResult)
     Assert.IsNotInstanceOfType(ParseResult, GetType(ParseError))
@@ -46,8 +46,8 @@ Public Class ArgHole_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _02_()
     Dim Text = "{}"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim ParseResult = FormatString.ArgHole.TryParse(FirstPos)
     Assert.IsNotNull(ParseResult)
     Assert.IsNotInstanceOfType(ParseResult, GetType(ParseError))
@@ -72,8 +72,8 @@ Public Class ArgHole_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _03_()
     Dim Text = "{0}"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim ParseResult = FormatString.ArgHole.TryParse(FirstPos)
     Assert.IsNotNull(ParseResult)
     Assert.IsNotInstanceOfType(ParseResult, GetType(ParseError))
@@ -101,8 +101,8 @@ Public Class ArgHole_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _04_()
     Dim Text = "{0 }"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim ParseResult = FormatString.ArgHole.TryParse(FirstPos)
     Assert.IsNotNull(ParseResult)
     Assert.IsNotInstanceOfType(ParseResult, GetType(ParseError))
@@ -132,8 +132,8 @@ Public Class ArgHole_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _05_()
     Dim Text = "{0 ,}"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim ParseResult = FormatString.ArgHole.TryParse(FirstPos)
     Assert.IsNotNull(ParseResult)
     Assert.IsNotInstanceOfType(ParseResult, GetType(ParseError))
@@ -160,8 +160,8 @@ Public Class ArgHole_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _06_()
     Dim Text = "{0 , :}"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim ParseResult = FormatString.ArgHole.TryParse(FirstPos)
     Assert.IsNotNull(ParseResult)
     Assert.IsNotInstanceOfType(ParseResult, GetType(ParseError))
@@ -193,8 +193,8 @@ Public Class ArgHole_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _07_()
     Dim Text = "{0 , 1}"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim ParseResult = FormatString.ArgHole.TryParse(FirstPos)
     Assert.IsNotNull(ParseResult)
     Assert.IsNotInstanceOfType(ParseResult, GetType(ParseError))
@@ -226,8 +226,8 @@ Public Class ArgHole_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _08_()
     Dim Text = "{0 , -1}"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim ParseResult = FormatString.ArgHole.TryParse(FirstPos)
     Assert.IsNotNull(ParseResult)
     Assert.IsNotInstanceOfType(ParseResult, GetType(ParseError))
@@ -259,8 +259,8 @@ Public Class ArgHole_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _09_()
     Dim Text = "{0 :{{}"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim ParseResult = FormatString.ArgHole.TryParse(FirstPos)
     Assert.IsNotNull(ParseResult)
     Assert.IsNotInstanceOfType(ParseResult, GetType(ParseError))

--- a/FSDv2_UnitTests/Arghole_UnitTest/ArgIndex_UnitTest/ArgIndex_UnitTest.vb
+++ b/FSDv2_UnitTests/Arghole_UnitTest/ArgIndex_UnitTest/ArgIndex_UnitTest.vb
@@ -11,8 +11,8 @@ Public Class ArgIndex_UnitTest
   <TestMethod, TestCategory("Tokens.Arghole.ArgIndex")>
   Public Sub _00_()
     Dim Text = ""
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Index.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(FormatString.ArgHole.Index))
@@ -23,8 +23,8 @@ Public Class ArgIndex_UnitTest
   <TestMethod, TestCategory("Tokens.Arghole.ArgIndex")>
   Public Sub _01_()
     Dim Text = "0"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Index.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.ArgHole.Index))
@@ -38,8 +38,8 @@ Public Class ArgIndex_UnitTest
   <TestMethod, TestCategory("Tokens.Arghole.ArgIndex")>
   Public Sub _02_()
     Dim Text = "01"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Index.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.ArgHole.Index))
@@ -57,8 +57,8 @@ Public Class ArgIndex_UnitTest
   <TestMethod, TestCategory("Tokens.Arghole.ArgIndex")>
   Public Sub _03_()
     Dim Text = "0  "
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Index.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.ArgHole.Index))
@@ -81,8 +81,8 @@ Public Class ArgIndex_UnitTest
   <TestMethod, TestCategory("Tokens.Arghole.ArgIndex")>
   Public Sub _04_()
     Dim Text = "01  "
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.ArgHole.Index.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.ArgHole.Index))
@@ -106,12 +106,12 @@ Public Class ArgIndex_UnitTest
   <TestMethod, TestCategory("Tokens.Arghole.ArgIndex")>
   Public Sub _05_()
     Dim Text = " 0"
-    ' (0:2) ArgIndex
-    ' [0] (0:1) ParseError (Why:= UnexpectedChacters)
-    '   [0] (0:1) Digits ?
-    ' [1] (1:1) Digits
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        ' (0:2) ArgIndex
+        ' [0] (0:1) ParseError (Why:= UnexpectedChacters)
+        '   [0] (0:1) Digits ?
+        ' [1] (1:1) Digits
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim ParseResult = FormatString.ArgHole.Index.TryParse(FirstPos)
     Assert.IsNotNull(ParseResult)
     Assert.IsInstanceOfType(ParseResult, GetType(FormatString.ArgHole.Index))
@@ -129,12 +129,12 @@ Public Class ArgIndex_UnitTest
   <TestMethod, TestCategory("Tokens.Arghole.ArgIndex")>
   Public Sub _06_()
     Dim Text = " 0  "
-    ' (0:2) ArgIndex
-    ' [0] (0:1) ParseError (Why:= UnexpectedChacters)
-    '   [0] (0:1) Digits ?
-    ' [1] (1:1) Digits
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        ' (0:2) ArgIndex
+        ' [0] (0:1) ParseError (Why:= UnexpectedChacters)
+        '   [0] (0:1) Digits ?
+        ' [1] (1:1) Digits
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim ParseResult = FormatString.ArgHole.Index.TryParse(FirstPos)
     Assert.IsNotNull(ParseResult)
     Assert.IsInstanceOfType(ParseResult, GetType(FormatString.ArgHole.Index))

--- a/FSDv2_UnitTests/FormatString_UnitTests.vb
+++ b/FSDv2_UnitTests/FormatString_UnitTests.vb
@@ -31,8 +31,8 @@ Public Class FSDv2_UnitTests
   <TestMethod, TestCategory(Cat0)>
   Public Sub _00_EmptyString()
     Dim TheText = ""
-    Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard)
-    Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
+        Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
     Dim Text = ParseResult.AsString()
     Dim Expected =
 "( -1:  0)  ParseError.NullParse
@@ -43,8 +43,8 @@ Public Class FSDv2_UnitTests
   <TestMethod, TestCategory(Cat0)>
   Public Sub _01_JustText()
     Dim TheText = "abc"
-    Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard)
-    Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
+        Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
     Dim Text = ParseResult.AsString()
     Dim Expected =
 "(  0:  3)  FormatString
@@ -56,8 +56,8 @@ Public Class FSDv2_UnitTests
   <TestMethod, TestCategory(Cat0)>
   Public Sub _02_Text_Brace_Closing()
     Dim TheText = "}"
-    Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard)
-    Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
+        Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
     Dim Text = ParseResult.AsString()
     Dim Expected =
 "(  0:  1)  FormatString
@@ -70,8 +70,8 @@ Public Class FSDv2_UnitTests
   <TestMethod, TestCategory(Cat0)>
   Public Sub _03_Text_Brace_Opening()
     Dim TheText = "{"
-    Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard)
-    Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
+        Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
     Dim Text = ParseResult.AsString()
     Dim Expected =
 "(  0:  1)  FormatString
@@ -85,8 +85,8 @@ Public Class FSDv2_UnitTests
   <TestMethod, TestCategory(Cat0)>
   Public Sub _04_EscapedOpening()
     Dim TheText = "{{"
-    Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard)
-    Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
+        Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
     Dim Text = ParseResult.AsString()
     Dim Expected =
 "(  0:  2)  FormatString
@@ -100,8 +100,8 @@ Public Class FSDv2_UnitTests
   <TestMethod, TestCategory(Cat0)>
   Public Sub _05_EscapedClosing()
     Dim TheText = "}}"
-    Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard)
-    Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
+        Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
     Dim Text = ParseResult.AsString()
     Dim Expected =
 "(  0:  2)  FormatString
@@ -115,8 +115,8 @@ Public Class FSDv2_UnitTests
   <TestMethod, TestCategory(Cat0)>
   Public Sub _06_EmptyArgHole()
     Dim TheText = "{}"
-    Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard)
-    Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
+        Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
     Dim Text = ParseResult.AsString()
     Dim Expected =
 "(  0:  2)  FormatString
@@ -133,8 +133,8 @@ Public Class FSDv2_UnitTests
   <TestMethod, TestCategory(Cat0)>
   Public Sub _07_EmptyArgHoles()
     Dim TheText = "{}{}"
-    Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard)
-    Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
+        Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
     Dim Text = ParseResult.AsString()
     Dim Expected =
 "(  0:  4)  FormatString
@@ -158,8 +158,8 @@ Public Class FSDv2_UnitTests
   Public Sub _08_()
     '              0123456
     Dim TheText = " {} {} "
-    Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard)
-    Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
+        Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
     Dim Text = ParseResult.AsString()
     Dim Expected = "(  0:  7)  FormatString
   [ 0]  (  0:  1)  Text
@@ -185,8 +185,8 @@ Public Class FSDv2_UnitTests
   Public Sub _09_()
     '              0123456
     Dim TheText = "}} {} {} {{"
-    Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard)
-    Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
+        Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
     Dim Text = ParseResult.AsString()
     Dim Expected =
 "(  0: 11)  FormatString
@@ -219,8 +219,8 @@ Public Class FSDv2_UnitTests
   Public Sub _10_()
     '              0123456
     Dim TheText = "{x}"
-    Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard)
-    Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
+        Dim TheSource = Source.Create(TheText, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim ParseResult = FormatString.TryParse(TheSource.First.Value)
     Dim Text = ParseResult.AsString()
     ' This should have a parse error of unexpected characters span (  1: 1).
     Dim Expected =

--- a/FSDv2_UnitTests/Source_UnitTests/Source_UnitTest_CB_Verbatum.vb
+++ b/FSDv2_UnitTests/Source_UnitTests/Source_UnitTest_CB_Verbatum.vb
@@ -10,8 +10,8 @@ Public Class Source_UnitTests_CS_Verbatum
   <TestMethod, TestCategory(Cat0)>
   Public Sub _00_NullText()
     Dim Text = Nothing
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Verbatum)
-    Assert.AreEqual(0, TheSource.Length)
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Verbatum, Source.StringKind.StringFormat)
+        Assert.AreEqual(0, TheSource.Length)
     Assert.AreEqual(Source.SourceKind.CS_Verbatum, TheSource.Kind)
     Assert.AreEqual("", TheSource.Text)
   End Sub
@@ -19,8 +19,8 @@ Public Class Source_UnitTests_CS_Verbatum
   <TestMethod, TestCategory(Cat0)>
   Public Sub _01_StringEmpty()
     Dim Text = String.Empty
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Verbatum)
-    Assert.AreEqual(0, TheSource.Length)
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Verbatum, Source.StringKind.StringFormat)
+        Assert.AreEqual(0, TheSource.Length)
     Assert.AreEqual(Source.SourceKind.CS_Verbatum, TheSource.Kind)
     Assert.AreEqual("", TheSource.Text)
   End Sub
@@ -28,8 +28,8 @@ Public Class Source_UnitTests_CS_Verbatum
   <TestMethod, TestCategory(Cat0)>
   Public Sub _02_EmptyStringLiteral()
     Dim Text = Nothing
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Verbatum)
-    Assert.AreEqual(0, TheSource.Length)
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Verbatum, Source.StringKind.StringFormat)
+        Assert.AreEqual(0, TheSource.Length)
     Assert.AreEqual(Source.SourceKind.CS_Verbatum, TheSource.Kind)
     Assert.AreEqual("", TheSource.Text)
   End Sub
@@ -37,8 +37,8 @@ Public Class Source_UnitTests_CS_Verbatum
   <TestMethod, TestCategory(Cat0)>
   Public Sub _03_SourceChar_Checks()
     Dim Text = "A"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Verbatum)
-    Assert.AreEqual(1, TheSource.Length)
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Verbatum, Source.StringKind.StringFormat)
+        Assert.AreEqual(1, TheSource.Length)
     Assert.AreEqual(Source.SourceKind.CS_Verbatum, TheSource.Kind)
     Assert.AreEqual("A", TheSource.Text)
     Dim res As Char?

--- a/FSDv2_UnitTests/Source_UnitTests/Source_UnitTest_CS_Standard.vb
+++ b/FSDv2_UnitTests/Source_UnitTests/Source_UnitTest_CS_Standard.vb
@@ -10,8 +10,8 @@ Public Class Source_UnitTests_CS_Standard
   <TestMethod, TestCategory(Cat0)>
   Public Sub _00_NullText()
     Dim Text = Nothing
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Assert.AreEqual(0, TheSource.Length)
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Assert.AreEqual(0, TheSource.Length)
     Assert.AreEqual(Source.SourceKind.CS_Standard, TheSource.Kind)
     Assert.AreEqual("", TheSource.Text)
   End Sub
@@ -19,8 +19,8 @@ Public Class Source_UnitTests_CS_Standard
   <TestMethod, TestCategory(Cat0)>
   Public Sub _01_StringEmpty()
     Dim Text = String.Empty
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Assert.AreEqual(0, TheSource.Length)
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Assert.AreEqual(0, TheSource.Length)
     Assert.AreEqual(Source.SourceKind.CS_Standard, TheSource.Kind)
     Assert.AreEqual("", TheSource.Text)
   End Sub
@@ -28,8 +28,8 @@ Public Class Source_UnitTests_CS_Standard
   <TestMethod, TestCategory(Cat0)>
   Public Sub _02_EmptyStringLiteral()
     Dim Text = Nothing
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Assert.AreEqual(0, TheSource.Length)
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Assert.AreEqual(0, TheSource.Length)
     Assert.AreEqual(Source.SourceKind.CS_Standard, TheSource.Kind)
     Assert.AreEqual("", TheSource.Text)
   End Sub
@@ -37,8 +37,8 @@ Public Class Source_UnitTests_CS_Standard
   <TestMethod, TestCategory(Cat0)>
   Public Sub _03_SourceChar_Checks()
     Dim Text = "A"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Assert.AreEqual(1, TheSource.Length)
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Assert.AreEqual(1, TheSource.Length)
     Assert.AreEqual(Source.SourceKind.CS_Standard, TheSource.Kind)
     Assert.AreEqual("A", TheSource.Text)
     Dim res As Char?

--- a/FSDv2_UnitTests/Source_UnitTests/Source_UnitTest_VB_Standard.vb
+++ b/FSDv2_UnitTests/Source_UnitTests/Source_UnitTest_VB_Standard.vb
@@ -11,8 +11,8 @@ Public Class Source_UnitTests_VB_Standard
   <TestMethod, TestCategory(Cat0)>
   Public Sub _00_NullText()
     Dim Text = Nothing
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Assert.AreEqual(0, TheSource.Length)
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Assert.AreEqual(0, TheSource.Length)
     Assert.AreEqual(Source.SourceKind.VB_Standard, TheSource.Kind)
     Assert.AreEqual("", TheSource.Text)
   End Sub
@@ -20,8 +20,8 @@ Public Class Source_UnitTests_VB_Standard
   <TestMethod, TestCategory(Cat0)>
   Public Sub _01_StringEmpty()
     Dim Text = String.Empty
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Assert.AreEqual(0, TheSource.Length)
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Assert.AreEqual(0, TheSource.Length)
     Assert.AreEqual(Source.SourceKind.VB_Standard, TheSource.Kind)
     Assert.AreEqual("", TheSource.Text)
   End Sub
@@ -29,8 +29,8 @@ Public Class Source_UnitTests_VB_Standard
   <TestMethod, TestCategory(Cat0)>
   Public Sub _02_EmptyStringLiteral()
     Dim Text = Nothing
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Assert.AreEqual(0, TheSource.Length)
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Assert.AreEqual(0, TheSource.Length)
     Assert.AreEqual(Source.SourceKind.VB_Standard, TheSource.Kind)
     Assert.AreEqual("", TheSource.Text)
   End Sub
@@ -38,8 +38,8 @@ Public Class Source_UnitTests_VB_Standard
   <TestMethod, TestCategory(Cat0)>
   Public Sub _03_SourceChar_Checks()
     Dim Text = "A"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Assert.AreEqual(1, TheSource.Length)
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Assert.AreEqual(1, TheSource.Length)
     Assert.AreEqual(Source.SourceKind.VB_Standard, TheSource.Kind)
     Assert.AreEqual("A", TheSource.Text)
     Dim res As Char?

--- a/FSDv2_UnitTests/Tokens/Common/Brace.vb
+++ b/FSDv2_UnitTests/Tokens/Common/Brace.vb
@@ -7,8 +7,8 @@ Imports FSDv2
   <TestMethod, TestCategory("Tokens.Common.Brace")>
   Public Sub _00_()
     Dim Text = ""
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Brace.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -30,8 +30,8 @@ Imports FSDv2
   <TestMethod, TestCategory("Tokens.Common.Brace")>
   Public Sub _02_()
     Dim Text = "}"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Brace.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Brace.Closing))
@@ -43,8 +43,8 @@ Imports FSDv2
   <TestMethod, TestCategory("Tokens.Common.Brace")>
   Public Sub _03_()
     Dim Text = "{{"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Brace.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Brace.Esc.Opening))
@@ -62,8 +62,8 @@ Imports FSDv2
   <TestMethod, TestCategory("Tokens.Common.Brace")>
   Public Sub _04_()
     Dim Text = "}}"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Brace.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Brace.Esc.Closing))
@@ -82,8 +82,8 @@ Imports FSDv2
   <TestMethod, TestCategory("Tokens.Common.Brace")>
   Public Sub _05_()
     Dim Text = "{ "
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Brace.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Brace.Opening))
@@ -95,8 +95,8 @@ Imports FSDv2
   <TestMethod, TestCategory("Tokens.Common.Brace")>
   Public Sub _06_()
     Dim Text = "} "
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Brace.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Brace.Closing))
@@ -108,8 +108,8 @@ Imports FSDv2
   <TestMethod, TestCategory("Tokens.Common.Brace")>
   Public Sub _07_()
     Dim Text = "{{ "
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Brace.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Brace.Esc.Opening))
@@ -127,8 +127,8 @@ Imports FSDv2
   <TestMethod, TestCategory("Tokens.Common.Brace")>
   Public Sub _08_()
     Dim Text = "}} "
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Brace.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Brace.Esc.Closing))

--- a/FSDv2_UnitTests/Tokens/Common/Digit.vb
+++ b/FSDv2_UnitTests/Tokens/Common/Digit.vb
@@ -8,16 +8,16 @@ Public Class Tokens_Common_Digit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Digit")>
   Public Sub _00_()
     Dim Text = ""
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Digit.TryParse(FirstPos)
   End Sub
 
   <TestMethod, TestCategory("Tokens.Common.Digit")>
   Public Sub _01_D0()
     Dim Text = "0"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Digit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Digit))
     Assert.AreEqual(TokenKind.Digit, res.Kind)
@@ -29,8 +29,8 @@ Public Class Tokens_Common_Digit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Digit")>
   Public Sub _02_D1()
     Dim Text = "1"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Digit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Digit))
     Assert.AreEqual(TokenKind.Digit, res.Kind)
@@ -42,8 +42,8 @@ Public Class Tokens_Common_Digit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Digit")>
   Public Sub _03_D2()
     Dim Text = "2"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Digit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Digit))
     Assert.AreEqual(TokenKind.Digit, res.Kind)
@@ -55,8 +55,8 @@ Public Class Tokens_Common_Digit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Digit")>
   Public Sub _04_D3()
     Dim Text = "3"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Digit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Digit))
     Assert.AreEqual(TokenKind.Digit, res.Kind)
@@ -68,8 +68,8 @@ Public Class Tokens_Common_Digit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Digit")>
   Public Sub _05_D4()
     Dim Text = "4"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Digit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Digit))
     Assert.AreEqual(TokenKind.Digit, res.Kind)
@@ -81,8 +81,8 @@ Public Class Tokens_Common_Digit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Digit")>
   Public Sub _06_D5()
     Dim Text = "5"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Digit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Digit))
     Assert.AreEqual(TokenKind.Digit, res.Kind)
@@ -94,8 +94,8 @@ Public Class Tokens_Common_Digit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Digit")>
   Public Sub _07_D6()
     Dim Text = "6"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Digit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Digit))
     Assert.AreEqual(TokenKind.Digit, res.Kind)
@@ -107,8 +107,8 @@ Public Class Tokens_Common_Digit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Digit")>
   Public Sub _08_D7()
     Dim Text = "7"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Digit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Digit))
     Assert.AreEqual(TokenKind.Digit, res.Kind)
@@ -120,8 +120,8 @@ Public Class Tokens_Common_Digit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Digit")>
   Public Sub _09_D8()
     Dim Text = "8"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Digit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Digit))
     Assert.AreEqual(TokenKind.Digit, res.Kind)
@@ -133,8 +133,8 @@ Public Class Tokens_Common_Digit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Digit")>
   Public Sub _10_D9()
     Dim Text = "9"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Digit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Digit))
     Assert.AreEqual(TokenKind.Digit, res.Kind)
@@ -146,8 +146,8 @@ Public Class Tokens_Common_Digit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Digit")>
   Public Sub _11_X()
     Dim Text = "X"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Digit.TryParse(FirstPos)
     Assert.IsNotInstanceOfType(res, GetType(FormatString.Common.Digit))
     Assert.IsInstanceOfType(res, GetType(ParseError))

--- a/FSDv2_UnitTests/Tokens/Common/Digits.vb
+++ b/FSDv2_UnitTests/Tokens/Common/Digits.vb
@@ -8,8 +8,8 @@ Public Class Tokens_Common_Digits_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Digits")>
   Public Sub _00_()
     Dim Text = ""
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Digits.TryParse(FirstPos)
 
 
@@ -18,8 +18,8 @@ Public Class Tokens_Common_Digits_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Digits")>
   Public Sub _01_()
     Dim Text = "0123456789"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Digits.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Digits))
     Assert.AreEqual(TokenKind.Digits, res.Kind)

--- a/FSDv2_UnitTests/Tokens/Common/EscSeq_Compound_Unicode.vb
+++ b/FSDv2_UnitTests/Tokens/Common/EscSeq_Compound_Unicode.vb
@@ -11,8 +11,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Cat)>
   Public Sub _00_()
     Dim Text = "\u"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -22,8 +22,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Cat)>
   Public Sub _01_()
     Dim Text = "\u"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Verbatum)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Verbatum, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -33,8 +33,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Cat)>
   Public Sub _02_()
     Dim Text = "\u"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -45,8 +45,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Cat)>
   Public Sub _03_()
     Dim Text = "\u0"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -54,8 +54,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Cat)>
   Public Sub _04_()
     Dim Text = "\u00"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -63,8 +63,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Cat)>
   Public Sub _05_()
     Dim Text = "\u000"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -72,8 +72,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Cat)>
   Public Sub _06_()
     Dim Text = "\u0000"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -81,8 +81,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Cat)>
   Public Sub _07_()
     Dim Text = "\u0000F"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -95,8 +95,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Dog)>
   Public Sub _10_()
     Dim Text = "\U"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -106,8 +106,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Dog)>
   Public Sub _11_()
     Dim Text = "\U"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Verbatum)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Verbatum, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -117,8 +117,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Dog)>
   Public Sub _12_()
     Dim Text = "\U"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -129,8 +129,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Dog)>
   Public Sub _13_()
     Dim Text = "\U0"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -138,8 +138,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Dog)>
   Public Sub _14_()
     Dim Text = "\U01"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -147,8 +147,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Dog)>
   Public Sub _15_()
     Dim Text = "\U012"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -156,8 +156,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Dog)>
   Public Sub _16_()
     Dim Text = "\U0123"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -165,8 +165,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Dog)>
   Public Sub _17_()
     Dim Text = "\U01234"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -174,8 +174,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Dog)>
   Public Sub _18_()
     Dim Text = "\U012345"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -183,8 +183,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Dog)>
   Public Sub _19_()
     Dim Text = "\U0123456"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -192,8 +192,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Dog)>
   Public Sub _20_()
     Dim Text = "\U01234567"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -202,8 +202,8 @@ Public Class EscSeq_Compound_Unicode
   <TestMethod, TestCategory(Dog)>
   Public Sub _21_()
     Dim Text = "\U01234567f"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))

--- a/FSDv2_UnitTests/Tokens/Common/EscSeq_Simple_Tests.vb
+++ b/FSDv2_UnitTests/Tokens/Common/EscSeq_Simple_Tests.vb
@@ -9,8 +9,8 @@ Imports FSDv2.FormatString.Common
   <TestMethod, TestCategory(Cat)>
   Public Sub _00_()
     Dim Text = "\'"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -20,8 +20,8 @@ Imports FSDv2.FormatString.Common
   <TestMethod, TestCategory(Cat)>
   Public Sub _01_()
     Dim Text = "\'"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Verbatum)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Verbatum, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsInstanceOfType(res, GetType(ParseError))
@@ -31,8 +31,8 @@ Imports FSDv2.FormatString.Common
   <TestMethod, TestCategory(Cat)>
   Public Sub _02_()
     Dim Text = "\'"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -42,8 +42,8 @@ Imports FSDv2.FormatString.Common
   <TestMethod, TestCategory(Cat)>
   Public Sub _03_()
     Dim Text = "\""" ' \"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -53,8 +53,8 @@ Imports FSDv2.FormatString.Common
   <TestMethod, TestCategory(Cat)>
   Public Sub _04_()
     Dim Text = "\\"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -64,8 +64,8 @@ Imports FSDv2.FormatString.Common
   <TestMethod, TestCategory(Cat)>
   Public Sub _05_()
     Dim Text = "\0"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -75,8 +75,8 @@ Imports FSDv2.FormatString.Common
   <TestMethod, TestCategory(Cat)>
   Public Sub _06_()
     Dim Text = "\a"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -86,8 +86,8 @@ Imports FSDv2.FormatString.Common
   <TestMethod, TestCategory(Cat)>
   Public Sub _07_()
     Dim Text = "\b"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -97,8 +97,8 @@ Imports FSDv2.FormatString.Common
   <TestMethod, TestCategory(Cat)>
   Public Sub _08_()
     Dim Text = "\f"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -108,8 +108,8 @@ Imports FSDv2.FormatString.Common
   <TestMethod, TestCategory(Cat)>
   Public Sub _09_()
     Dim Text = "\n"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -119,8 +119,8 @@ Imports FSDv2.FormatString.Common
   <TestMethod, TestCategory(Cat)>
   Public Sub _10_()
     Dim Text = "\r"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -130,8 +130,8 @@ Imports FSDv2.FormatString.Common
   <TestMethod, TestCategory(Cat)>
   Public Sub _11_()
     Dim Text = "\t"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -141,8 +141,8 @@ Imports FSDv2.FormatString.Common
   <TestMethod, TestCategory(Cat)>
   Public Sub _12_()
     Dim Text = "\v"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Esc.Sequence.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))

--- a/FSDv2_UnitTests/Tokens/Common/HexDigit.vb
+++ b/FSDv2_UnitTests/Tokens/Common/HexDigit.vb
@@ -8,16 +8,16 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _00_()
     Dim Text = ""
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
   End Sub
 
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _01_D0()
     Dim Text = "0"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -28,8 +28,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _02_D1()
     Dim Text = "1"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -40,8 +40,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _03_D2()
     Dim Text = "2"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -52,8 +52,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _04_D3()
     Dim Text = "3"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -64,8 +64,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _05_D4()
     Dim Text = "4"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -76,8 +76,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _06_D5()
     Dim Text = "5"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -88,8 +88,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _07_D6()
     Dim Text = "6"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -100,8 +100,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _08_D7()
     Dim Text = "7"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -112,8 +112,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _09_D8()
     Dim Text = "8"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -124,8 +124,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _10_D9()
     Dim Text = "9"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -137,8 +137,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _11_DA()
     Dim Text = "A"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -149,8 +149,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _12_DB()
     Dim Text = "B"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -161,8 +161,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _13_DC()
     Dim Text = "C"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -173,8 +173,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _14_DD()
     Dim Text = "D"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -185,8 +185,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _15_DE()
     Dim Text = "E"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -197,8 +197,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _16_DF()
     Dim Text = "F"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -210,8 +210,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _17_Dla()
     Dim Text = "a"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -222,8 +222,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _18_Dlb()
     Dim Text = "b"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -234,8 +234,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _19_Dlc()
     Dim Text = "c"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -246,8 +246,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _20_Dld()
     Dim Text = "d"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -258,8 +258,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _21_Dle()
     Dim Text = "e"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -270,8 +270,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _22_Dlf()
     Dim Text = "f"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigit))
     Assert.AreEqual(TokenKind.HexDigit, res.Kind)
@@ -283,8 +283,8 @@ Public Class Tokens_Common_HexDigit_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigit")>
   Public Sub _23_X()
     Dim Text = "X"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigit.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(FormatString.Common.HexDigit))

--- a/FSDv2_UnitTests/Tokens/Common/HexDigits.vb
+++ b/FSDv2_UnitTests/Tokens/Common/HexDigits.vb
@@ -8,8 +8,8 @@ Public Class Tokens_Common_HexDigits_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigits")>
   Public Sub _00_()
     Dim Text = ""
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigits.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(FormatString.Common.HexDigit))
@@ -22,8 +22,8 @@ Public Class Tokens_Common_HexDigits_UnitTest
   <TestMethod, TestCategory("Tokens.Common.HexDigits")>
   Public Sub _01_()
     Dim Text = "0123456789ABCDEFabcdef"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.HexDigits.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.HexDigits))
     Assert.AreEqual(TokenKind.HexDigits, res.Kind)

--- a/FSDv2_UnitTests/Tokens/Common/Whitespace.vb
+++ b/FSDv2_UnitTests/Tokens/Common/Whitespace.vb
@@ -8,8 +8,8 @@ Public Class Tokens_Common_Whitespace_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Whitespace")>
   Public Sub _00_()
     Dim Text = ""
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Whitespace.TryParse(FirstPos)
 
 
@@ -18,8 +18,8 @@ Public Class Tokens_Common_Whitespace_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Whitespace")>
   Public Sub _01_()
     Dim Text = " "
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Whitespace.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Whitespace))
     Assert.AreEqual(TokenKind.Whitespace, res.Kind)

--- a/FSDv2_UnitTests/Tokens/Common/Whitespaces.vb
+++ b/FSDv2_UnitTests/Tokens/Common/Whitespaces.vb
@@ -8,8 +8,8 @@ Public Class Tokens_Common_Whitespaces_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Whitespaces")>
   Public Sub _00_()
     Dim Text = ""
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Whitespaces.TryParse(FirstPos)
 
 
@@ -18,8 +18,8 @@ Public Class Tokens_Common_Whitespaces_UnitTest
   <TestMethod, TestCategory("Tokens.Common.Whitespaces")>
   Public Sub _01_()
     Dim Text = " "
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Common.Whitespaces.TryParse(FirstPos)
     Assert.IsInstanceOfType(res, GetType(FormatString.Common.Whitespaces))
     Assert.AreEqual(TokenKind.Whitespaces, res.Kind)

--- a/FSDv2_UnitTests/Tokens/Text_UnitTest.vb
+++ b/FSDv2_UnitTests/Tokens/Text_UnitTest.vb
@@ -12,8 +12,8 @@ Public Class Text_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _00_()
     Dim Text = ""
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Text.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -24,8 +24,8 @@ Public Class Text_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _01_()
     Dim Text = "abc"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Text.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -35,8 +35,8 @@ Public Class Text_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _02_()
     Dim Text = "abc\b"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.VB_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Text.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -46,8 +46,8 @@ Public Class Text_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _03_()
     Dim Text = "abc\b"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Text.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -61,8 +61,8 @@ Public Class Text_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _04_()
     Dim Text = "abc\q"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Text.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -75,8 +75,8 @@ Public Class Text_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _05_()
     Dim Text = "abc\x"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Text.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))
@@ -90,8 +90,8 @@ Public Class Text_UnitTests
   <TestMethod, TestCategory(Cat)>
   Public Sub _06_()
     Dim Text = "abc\x0000f"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim FirstPos = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim FirstPos = TheSource.First
     Dim res = FormatString.Text.TryParse(FirstPos)
     Assert.IsNotNull(res)
     Assert.IsNotInstanceOfType(res, GetType(ParseError))

--- a/Module1.vb
+++ b/Module1.vb
@@ -8,8 +8,8 @@ Module Module1
     '           0         1         2         3         4         5         6         7         8
     '           012345678901234567890123456789012345678901234567890123456789012345678901234567890
     Dim Text = "{}"
-    Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard)
-    Dim Ix = TheSource.First
+        Dim TheSource = Source.Create(Text, Source.SourceKind.CS_Standard, Source.StringKind.StringFormat)
+        Dim Ix = TheSource.First
     'Dim sw = Diagnostics.Stopwatch.StartNew
     Dim ParseResult = FormatString.TryParse(Ix)
     Console.WriteLine($"Input:=[{Text}]")


### PR DESCRIPTION
Does this by introducing a new enum (StringKind) and a read-only propery KindOfString in Source